### PR TITLE
chore: update repository template to 8042a8da

### DIFF
--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -1,5 +1,5 @@
-titleOnly: false
-commitsOnly: true
+titleOnly: true
+commitsOnly: false
 titleAndCommits: false
 
 types:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,11 +4,11 @@ Thank you for contributing changes to this document! Because we use a central re
 to synchronize this file across all our repositories, make sure to make your edits
 in the correct file, which you can find here:
 
-https://github.com/ory/meta/blob/master/templates/repository/CONTRIBUTING.md
+https://github.com/ory/meta/blob/master/templates/repository/common/CONTRIBUTING.md
 
 -->
 
-# Contributing to ORY {{Project}}
+# Contributing to ORY Milestone Action
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
@@ -33,8 +33,8 @@ There are many ways in which you can contribute, beyond writing code. The goal
 of this document is to provide a high-level overview of how you can get
 involved.
 
-_Please note_: We take ORY {{Project}}'s security and our users' trust very
-seriously. If you believe you have found a security issue in ORY {{Project}},
+_Please note_: We take ORY Milestone Action's security and our users' trust very
+seriously. If you believe you have found a security issue in ORY Milestone Action,
 please responsibly disclose by contacting us at security@ory.sh.
 
 First: As a potential contributor, your changes and ideas are welcome at any
@@ -48,50 +48,50 @@ contributions, and don't want a wall of rules to get in the way of that.
 
 That said, if you want to ensure that a pull request is likely to be merged,
 talk to us! You can find out our thoughts and ensure that your contribution
-won't clash or be obviated by ORY {{Project}}'s normal direction. A great way to
+won't clash or be obviated by ORY Milestone Action's normal direction. A great way to
 do this is via the [ORY Community](https://community.ory.sh/) or join the
 [ORY Chat](https://www.ory.sh/chat).
 
 ## FAQ
 
 - I am new to the community. Where can I find the
-  [ORY Community Code of Conduct?](CODE_OF_CONDUCT.md)
+  [ORY Community Code of Conduct?](https://github.com/ory/Milestone Action/blob/master/CODE_OF_CONDUCT.md)
 
 - I have a question. Where can I get
-  [answers to questions regarding ORY {{Project}}?](#communication)
+  [answers to questions regarding ORY Milestone Action?](#communication)
 
 - I would like to contribute but I am not sure how. Are there
   [easy ways to contribute?](#how-can-i-contribute)
   [Or good first issues?](https://github.com/search?l=&o=desc&q=label%3A%22help+wanted%22+label%3A%22good+first+issue%22+is%3Aopen+user%3Aory+user%3Aory-corp&s=updated&type=Issues)
 
-- I want to talk to other ORY {{Project}} users.
+- I want to talk to other ORY Milestone Action users.
   [How can I become a part of the community?](#communication)
 
 - I would like to know what I am agreeing to when I contribute to ORY
-  {{Project}}. Does ORY have
+  Milestone Action. Does ORY have
   [a Contributors License Agreement?](https://cla-assistant.io/ory/)
 
-- I would like updates about new versions of ORY {{Project}}.
+- I would like updates about new versions of ORY Milestone Action.
   [How are new releases announced?](https://ory.us10.list-manage.com/subscribe?u=ffb1a878e4ec6c0ed312a3480&id=f605a41b53)
 
 ## How can I contribute?
 
 If you want to start contributing code right away, we have a
-[list of good first issues](https://github.com/ory/{{Project}}/labels/good%20first%20issue).
+[list of good first issues](https://github.com/ory/Milestone Action/labels/good%20first%20issue).
 
 There are many other ways you can contribute without writing any code. Here are
 a few things you can do to help out:
 
 - **Give us a star.** It may not seem like much, but it really makes a
   difference. This is something that everyone can do to help out ORY
-  {{Project}}. Github stars help the project gain visibility and stand out.
+  Milestone Action. Github stars help the project gain visibility and stand out.
 
 - **Join the community.** Sometimes helping people can be as easy as listening
   to their problems and offering a different perspective. Join our Slack, have a
   look at discussions in the forum and take part in our weekly hangout. More
   info on this in [Communication](#communication).
 
-- **Helping with open issues.** We have a lot of open issues for ORY {{Project}}
+- **Helping with open issues.** We have a lot of open issues for ORY Milestone Action
   and some of them may lack necessary information, some are duplicates of older
   issues. You can help out by guiding people through the process of filling out
   the issue template, asking for clarifying information, or pointing them to
@@ -113,11 +113,11 @@ questions, discuss bugs and feature requests, talk to other users of ORY, etc.
 We have a [forum](https://community.ory.sh/). This is a great place for in-depth
 discussions and lots of code examples, logs and similar data.
 
-You can also join our weekly hangout, if you want to speak to the ORY team
+You can also join our community hangout, if you want to speak to the ORY team
 directly or ask some questions. You can find more info on the hangouts in
 [Slack](https://www.ory.sh/chat).
 
-If you want to receive regular notifications about updates to ORY {{Project}},
+If you want to receive regular notifications about updates to ORY Milestone Action,
 consider joining the mailing list. We will _only_ send you vital information on
 the projects that you are interested in.
 
@@ -127,7 +127,7 @@ Also [follow us on twitter](https://twitter.com/orycorp).
 
 Unless you are fixing a known bug, we **strongly** recommend discussing it with
 the core team via a GitHub issue or [in our chat](https://www.ory.sh/chat)
-before getting started to ensure your work is consistent with ORY {{Project}}'s
+before getting started to ensure your work is consistent with ORY Milestone Action's
 roadmap and architecture.
 
 All contributions are made via pull request. Note that **all patches from all
@@ -157,10 +157,12 @@ should be merged by the submitter after review.
 ## Documentation
 
 Please provide documentation when changing, removing, or adding features.
-Documentation resides in the project's [docs](docs) folder. Generate API and
-configuration reference documentation using `cd docs; npm run gen`.
+Documentation resides in the project's
+[docs](https://github.com/ory/Milestone Action/tree/master/docs) folder. Generate API
+and configuration reference documentation using `cd docs; npm run gen`.
 
-For further instructions please head over to [docs/README.md](docs/README.md).
+For further instructions please head over to
+[docs/README.md](https://github.com/ory/Milestone Action/blob/master/README.md).
 
 ## Disclosing vulnerabilities
 
@@ -203,10 +205,10 @@ please include a note in your commit message explaining why.
 
 ```
 # First you clone the original repository
-git clone git@github.com:ory/{{Project}}.git
+git clone git@github.com:ory/Milestone Action.git
 
 # Next you add a git remote that is your fork:
-git remote add fork git@github.com:<YOUR-GITHUB-USERNAME-HERE>/{{Project}}.git
+git remote add fork git@github.com:<YOUR-GITHUB-USERNAME-HERE>/Milestone Action.git
 
 # Next you fetch the latest changes from origin for master:
 git fetch origin
@@ -243,7 +245,7 @@ community a safe place for you and we've got your back.
 - Private harassment is also unacceptable. No matter who you are, if you feel
   you have been or are being harassed or made uncomfortable by a community
   member, please contact one of the channel ops or a member of the ORY
-  {{Project}} core team immediately.
+  Milestone Action core team immediately.
 - Likewise any spamming, trolling, flaming, baiting or other attention-stealing
   behaviour is not welcome.
 


### PR DESCRIPTION
Updated repository templates to https://github.com/ory/meta/commit/8042a8da0b42c9ff50deb9860249f95c756af18f.