### PR TITLE
chore: update Ory CLI with breaking changes to the format task

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 format: .bin/ory node_modules   # formats the source code
-	.bin/ory dev headers license
+	.bin/ory dev headers copyright
 	npm exec -- prettier --write .
 
 help:
@@ -12,7 +12,7 @@ licenses: .bin/licenses node_modules  # checks open-source licenses
 	curl https://raw.githubusercontent.com/ory/ci/master/licenses/install | sh
 
 .bin/ory: Makefile
-	curl https://raw.githubusercontent.com/ory/meta/master/install.sh | bash -s -- -b .bin ory v0.1.47
+	curl https://raw.githubusercontent.com/ory/meta/master/install.sh | bash -s -- -b .bin ory v0.1.48
 	touch .bin/ory
 
 node_modules: package-lock.json

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 format: .bin/ory node_modules   # formats the source code
-	.bin/ory dev headers copyright
+	.bin/ory dev headers copyright --type=open-source
 	npm exec -- prettier --write .
 
 help:


### PR DESCRIPTION
https://github.com/ory/cli/pull/257 changed the name of the command to add copyright headers to files. Ship this PR after Ory CLI v0.1.48 ships.